### PR TITLE
Loosen mr refs to allow strings or numbers

### DIFF
--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -1,11 +1,19 @@
+import { z } from 'zod'
+
 // Ref describes the structure of existing bundled data
-export type Ref = { name: string } & Kind
-export type Kind =
-  | { doi: string }
-  | { wikipedia: string }
-  | { mr: string }
-  | { mathse: string }
-  | { mo: string }
+export const refSchema = z.intersection(
+  // TODO: name presumably shouldn't be optional, but T000275 needs to be fixed
+  z.object({ name: z.string().optional() }),
+  z.union([
+    z.object({ doi: z.string() }),
+    z.object({ wikipedia: z.string() }),
+    z.object({ mr: z.string() }),
+    z.object({ mr: z.number() }),
+    z.object({ mathse: z.number() }),
+    z.object({ mo: z.number() }),
+  ])
+)
+export type Ref = z.infer<typeof refSchema>
 
 // TaggedRef is intended to be easier to operate (switch) on
 export type TaggedRef =
@@ -23,10 +31,10 @@ export function tag(ref: Ref): TaggedRef {
   } else if ('wikipedia' in ref) {
     return { kind: 'wikipedia', id: ref.wikipedia, name }
   } else if ('mr' in ref) {
-    return { kind: 'mr', id: ref.mr, name }
+    return { kind: 'mr', id: String(ref.mr), name }
   } else if ('mathse' in ref) {
-    return { kind: 'mathse', id: ref.mathse, name }
+    return { kind: 'mathse', id: String(ref.mathse), name }
   } else {
-    return { kind: 'mo', id: ref.mo, name }
+    return { kind: 'mo', id: String(ref.mo), name }
   }
 }

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -2,8 +2,7 @@ import { z } from 'zod'
 
 // Ref describes the structure of existing bundled data
 export const refSchema = z.intersection(
-  // TODO: name presumably shouldn't be optional, but T000275 needs to be fixed
-  z.object({ name: z.string().optional() }),
+  z.object({ name: z.string() }),
   z.union([
     z.object({ doi: z.string() }),
     z.object({ wikipedia: z.string() }),


### PR DESCRIPTION
It's very tempting to write YAML like `mr: 123456` but we are expecting a string like `mr: '123456'` or `mr: MR123456`. This allows for this flexibility.

Closes https://github.com/pi-base/web/issues/15

I'm also willing to say that we shouldn't allow this flexibility. But if we're inflexible, I actually prefer requiring mr *numbers* rather than the duplicate "mr" in `mr: MR123456` .
